### PR TITLE
Correções Pontuais

### DIFF
--- a/docs/transactions/credito-parcelado.md
+++ b/docs/transactions/credito-parcelado.md
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
         val creditParameter = CreditParameters(
             installments = 2,  // Número de parcelas
             amount = BigDecimal("100.00"),  // Valor da transação
-            creditType =  CreditTransactionType.AT_SIGHT // Crédito parcelado
+            creditType =  CreditTransactionType.STORE_INSTALMENTS // Crédito parcelado lojista
         )
 
         paykit.credit(creditParameter, object : Callback<PaymentResult> {

--- a/docs/transactions/debito.md
+++ b/docs/transactions/debito.md
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
             debitType = DebitTransactionType.AT_SIGHT // Débito à vista
         )
 
-        paykit.credit(debitParameter, object : Callback<PaymentResult> {
+        paykit.debit(debitParameter, object : Callback<PaymentResult> {
             override fun execute(result: PaymentResult) {
                 Log.i("PaymentResult", "ID: ${result.id}, Transaction: ${result.transactionData}")
                 onPaymentResult(result.id, result.transactionData)

--- a/docs/transactions/index.md
+++ b/docs/transactions/index.md
@@ -34,4 +34,4 @@ O SDK Único atualmente suporta as seguintes operações.
   [Wallet]: wallet.md
   [Estorno]: estorno.md
   [Reimpressão]: reimpressao.md
-  [Impressão]: reimpressao.md
+  [Impressão]: impressao.md


### PR DESCRIPTION
Correção levantada por Postos

1. Na página de operações da SDK, o link do card 'Impressão' leva para a página 'Reimpressão'. Mas já no menu lateral a opção 'Impressão' leva para a página correta. Acredito que o link do card deveria ser o mesmo;
 
2. No exemplo de código do crédito parcelado, o creditType passado como parâmetro está como AT_SIGHT, mas que talvez o correto seria utilizar outro valor, como STORE_INSTALMENTS;
 
3. No exemplo de código do débito, a função chamada está como 'credit', mas acredito que o correto seria 'debit'.